### PR TITLE
Gnome 41 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Turn on your GNOME dark mode!",
   "uuid": "gnometoggle@foreverxml.github.io",
   "original-author": "foreverxml@tuta.io",
-  "shell-version": ["3.36","3.38","40"],
+  "shell-version": ["3.36","3.38","40","41"],
   "url": "https://github.com/foreverxml/gnome-toggle",
   "version": "1.1"
 }


### PR DESCRIPTION
All it takes for Gnome 41 support is changing the value of `shell-version` in metadata.json, which is what this PR does. I tested it out and it works flawlessly.